### PR TITLE
Only modify ActiveSupport environment if ActiveSupport::Inflector is loaded

### DIFF
--- a/lib/titleize.rb
+++ b/lib/titleize.rb
@@ -82,7 +82,7 @@ class String
   #   "notes on a scandal" # => "Notes on a Scandal"
   #   "the good german"    # => "The Good German"
   def titleize(opts={})
-    if defined? ActiveSupport
+    if (defined? ActiveSupport) && (defined? ActiveSupport::Inflector)
       ActiveSupport::Inflector.titleize(self, opts)
     else
       Titleize.titleize(self)
@@ -96,7 +96,7 @@ class String
   alias_method :titlecase!, :titleize!
 end
 
-if defined? ActiveSupport
+if (defined? ActiveSupport) && (defined? ActiveSupport::Inflector)
   module ActiveSupport::Inflector
     extend self
 


### PR DESCRIPTION
In some cases (my application exhibits this), ActiveSupport will exist but ActiveSupport::Inflector won't; however, the library only checks to see if ActiveSupport exists.  This patch fixes the issue.